### PR TITLE
Fix canvasTest function call inside worker (issue with mangle option)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ function handleMethod(settings) {
     // Create web worker
     if (settings.useWorker && hasOffscreenCanvasSupport) {
         const js = `
-            ${canvasTest.toString()}
+            var canvasTest = ${canvasTest.toString()};
             onmessage = function(e) {
                 canvasTest(e.data);
             };


### PR DESCRIPTION
Hello!

The issue which was described here https://github.com/jhildenbiddle/canvas-size/issues/6 and here https://github.com/jhildenbiddle/canvas-size/issues/5 is still reproducable for React applications which are being built by `react-scripts`. The thing is that it's impossible to change `mangle` option without ejecting.

The idea of pull request is to not rely that function with name `canvasTest` will be initialized, but to assign this function to `canvasTest` variable.

I found that this will work for React and this solution is not depended on `mangle` option for [Terser](https://github.com/terser/terser)  configuration

@jhildenbiddle  What do you think about suggested fix of this problem?

Thanks!