### PR TITLE
add iOS 14.6 test result

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Tests conducted using [BrowserStack](https://www.browserstack.com/) virtualized 
 | Chrome 68 (Android 5) *       |    32,767 |     32,767 | 11,402 x 11,402 (130,005,604) |
 | Chrome 68 (Android 4.4) *     |    32,767 |     32,767 | 16,384 x 16,384 (268,435,456) |
 | IE (Windows Phone 8.x)        |     4,096 |      4,096 |  4,096 x  4,096  (16,777,216) |
-| Safari (iOS 9 - 12)           | 4,194,303 |  8,388,607 |  4,096 x  4,096  (16,777,216) |
+| Safari (iOS 9 - 14.6)         | 4,194,303 |  8,388,607 |  4,096 x  4,096  (16,777,216) |
 
 ## Known Issues
 


### PR DESCRIPTION
Performed this test on iOS (iPhone OS) 14.6 with Safari 14.1.1. Max canvas dimensions are still the same.

![IMG_0885](https://user-images.githubusercontent.com/1074328/127604704-1ceb8304-1735-4869-aef9-8c4fc3122baa.PNG)
![IMG_0884](https://user-images.githubusercontent.com/1074328/127604707-384669ed-c842-4244-8435-17f061636056.PNG)
